### PR TITLE
Add gptq support

### DIFF
--- a/qwen/build.py
+++ b/qwen/build.py
@@ -5,8 +5,10 @@ import ctypes
 import tensorrt as trt
 import torch
 import torch.multiprocessing as mp
+
 # for release runing
 from transformers import AutoConfig, AutoModelForCausalLM
+
 # for debug runing
 # from qwen_7b_chat.configuration_qwen import QWenConfig as AutoConfig
 # from qwen_7b_chat.modeling_qwen import QWenLMHeadModel as AutoModelForCausalLM
@@ -15,9 +17,12 @@ import tensorrt_llm
 from tensorrt_llm._utils import str_dtype_to_trt
 from tensorrt_llm.builder import Builder
 from tensorrt_llm.logger import logger
-from tensorrt_llm.models import (fp8_quantize, smooth_quantize,
-                                 weight_only_groupwise_quantize,
-                                 weight_only_quantize)
+from tensorrt_llm.models import (
+    fp8_quantize,
+    smooth_quantize,
+    weight_only_groupwise_quantize,
+    weight_only_quantize,
+)
 from tensorrt_llm.network import net_guard
 from tensorrt_llm.plugin.plugin import ContextFMHAType
 from tensorrt_llm.quantization import QuantMode
@@ -57,16 +62,22 @@ def to_onnx(network, path):
         network_input = network.get_input(i)
         inputs.append(
             helper.make_tensor_value_info(
-                network_input.name, trt_dtype_to_onnx(network_input.dtype),
-                list(network_input.shape)))
+                network_input.name,
+                trt_dtype_to_onnx(network_input.dtype),
+                list(network_input.shape),
+            )
+        )
 
     outputs = []
     for i in range(network.num_outputs):
         network_output = network.get_output(i)
         outputs.append(
             helper.make_tensor_value_info(
-                network_output.name, trt_dtype_to_onnx(network_output.dtype),
-                list(network_output.shape)))
+                network_output.name,
+                trt_dtype_to_onnx(network_output.dtype),
+                list(network_output.shape),
+            )
+        )
 
     nodes = []
     for i in range(network.num_layers):
@@ -76,277 +87,267 @@ def to_onnx(network, path):
             ipt = layer.get_input(j)
             if ipt is not None:
                 layer_inputs.append(layer.get_input(j).name)
-        layer_outputs = [
-            layer.get_output(j).name for j in range(layer.num_outputs)
-        ]
+        layer_outputs = [layer.get_output(j).name for j in range(layer.num_outputs)]
         nodes.append(
-            helper.make_node(str(layer.type),
-                             name=layer.name,
-                             inputs=layer_inputs,
-                             outputs=layer_outputs,
-                             domain="com.nvidia"))
+            helper.make_node(
+                str(layer.type),
+                name=layer.name,
+                inputs=layer_inputs,
+                outputs=layer_outputs,
+                domain="com.nvidia",
+            )
+        )
 
-    onnx_model = helper.make_model(helper.make_graph(nodes,
-                                                     'attention',
-                                                     inputs,
-                                                     outputs,
-                                                     initializer=None),
-                                   producer_name='NVIDIA')
+    onnx_model = helper.make_model(
+        helper.make_graph(nodes, "attention", inputs, outputs, initializer=None),
+        producer_name="NVIDIA",
+    )
     onnx.save(onnx_model, path)
 
 
 def get_engine_name(model, dtype, tp_size, pp_size, rank):
     if pp_size == 1:
-        return '{}_{}_tp{}_rank{}.engine'.format(model, dtype, tp_size, rank)
-    return '{}_{}_tp{}_pp{}_rank{}.engine'.format(model, dtype, tp_size,
-                                                  pp_size, rank)
+        return "{}_{}_tp{}_rank{}.engine".format(model, dtype, tp_size, rank)
+    return "{}_{}_tp{}_pp{}_rank{}.engine".format(model, dtype, tp_size, pp_size, rank)
 
 
 def serialize_engine(engine, path):
-    logger.info(f'Serializing engine to {path}...')
+    logger.info(f"Serializing engine to {path}...")
     tik = time.time()
-    with open(path, 'wb') as f:
+    with open(path, "wb") as f:
         f.write(bytearray(engine))
     tok = time.time()
-    t = time.strftime('%H:%M:%S', time.gmtime(tok - tik))
-    logger.info(f'Engine serialized. Total time: {t}')
+    t = time.strftime("%H:%M:%S", time.gmtime(tok - tik))
+    logger.info(f"Engine serialized. Total time: {t}")
 
 
 def parse_arguments():
     parser = argparse.ArgumentParser()
     parser.add_argument(
-        '--world_size',
+        "--world_size",
         type=int,
         default=1,
-        help='world size, only support tensor parallelism now'
+        help="world size, only support tensor parallelism now",
     )
-    parser.add_argument('--tp_size', type=int, default=1)
-    parser.add_argument('--pp_size', type=int, default=1)
+    parser.add_argument("--tp_size", type=int, default=1)
+    parser.add_argument("--pp_size", type=int, default=1)
     parser.add_argument(
-        '--hf_model_dir',
+        "--hf_model_dir",
         type=str,
         default=default_config.hf_model_dir,
     )
     parser.add_argument(
-        '--ft_dir_path',
+        "--ft_dir_path",
         type=str,
         default=default_config.ft_dir_path,
     )
     parser.add_argument(
-        '--dtype',
+        "--dtype",
         type=str,
-        default='float16',
-        choices=['float32', 'bfloat16', 'float16']
+        default="float16",
+        choices=["float32", "bfloat16", "float16"],
     )
     parser.add_argument(
-        '--timing_cache',
+        "--timing_cache",
         type=str,
-        default='model.cache',
-        help=
-        'The path of to read timing cache from, will be ignored if the file does not exist'
+        default="model.cache",
+        help="The path of to read timing cache from, will be ignored if the file does not exist",
     )
     parser.add_argument(
-        '--log_level',
+        "--log_level",
         type=str,
-        default='info',
+        default="info",
         choices=[
-            'internal_error',
-            'error',
-            'warning',
-            'info',
-            'verbose',
-        ]
+            "internal_error",
+            "error",
+            "warning",
+            "info",
+            "verbose",
+        ],
     )
-    parser.add_argument('--vocab_size', type=int, default=32000)
-    parser.add_argument('--n_layer', type=int, default=32)
-    parser.add_argument('--n_positions', type=int, default=2048)
-    parser.add_argument('--n_embd', type=int, default=4096)
-    parser.add_argument('--n_head', type=int, default=32)
-    parser.add_argument('--n_kv_head', type=int, default=None)
-    parser.add_argument('--multiple_of', type=int, default=None)
-    parser.add_argument('--ffn_dim_multiplier', type=int, default=1)
-    parser.add_argument('--inter_size', type=int, default=11008)
-    parser.add_argument('--hidden_act', type=str, default='silu')
-    parser.add_argument('--max_batch_size', type=int, default=default_config.trt_max_batch_size)
-    parser.add_argument('--max_input_len', type=int, default=default_config.max_input_len)
-    parser.add_argument('--max_new_tokens', type=int, default=default_config.max_new_tokens)
-    parser.add_argument('--max_beam_width', type=int, default=1)
-    parser.add_argument('--rotary_base', type=float, default=10000.0)
-    parser.add_argument('--rotary_scaling', nargs=2, type=str, default=None)
+    parser.add_argument("--vocab_size", type=int, default=32000)
+    parser.add_argument("--n_layer", type=int, default=32)
+    parser.add_argument("--n_positions", type=int, default=2048)
+    parser.add_argument("--n_embd", type=int, default=4096)
+    parser.add_argument("--n_head", type=int, default=32)
+    parser.add_argument("--n_kv_head", type=int, default=None)
+    parser.add_argument("--multiple_of", type=int, default=None)
+    parser.add_argument("--ffn_dim_multiplier", type=int, default=1)
+    parser.add_argument("--inter_size", type=int, default=11008)
+    parser.add_argument("--hidden_act", type=str, default="silu")
     parser.add_argument(
-        '--use_gpt_attention_plugin',
-        nargs='?',
+        "--max_batch_size", type=int, default=default_config.trt_max_batch_size
+    )
+    parser.add_argument(
+        "--max_input_len", type=int, default=default_config.max_input_len
+    )
+    parser.add_argument(
+        "--max_new_tokens", type=int, default=default_config.max_new_tokens
+    )
+    parser.add_argument("--max_beam_width", type=int, default=1)
+    parser.add_argument("--rotary_base", type=float, default=10000.0)
+    parser.add_argument("--rotary_scaling", nargs=2, type=str, default=None)
+    parser.add_argument(
+        "--use_gpt_attention_plugin",
+        nargs="?",
         type=str,
         default="float16",
-        choices=['float16', 'bfloat16', 'float32', None]
+        choices=["float16", "bfloat16", "float32", None],
     )
     parser.add_argument(
-        '--use_gemm_plugin',
-        nargs='?',
+        "--use_gemm_plugin",
+        nargs="?",
         type=str,
         default="float16",
-        choices=['float16', 'bfloat16', 'float32', None]
+        choices=["float16", "bfloat16", "float32", None],
     )
-    parser.add_argument('--parallel_build', default=False, action='store_true')
-    parser.add_argument('--enable_context_fmha',
-                        default=False,
-                        action='store_true')
-    parser.add_argument('--enable_context_fmha_fp32_acc',
-                        default=False,
-                        action='store_true')
-    parser.add_argument('--visualize', default=False, action='store_true')
-    parser.add_argument('--enable_debug_output',
-                        default=False,
-                        action='store_true')
-    parser.add_argument('--gpus_per_node', type=int, default=8)
-    parser.add_argument('--builder_opt', type=int, default=None)
+    parser.add_argument("--parallel_build", default=False, action="store_true")
+    parser.add_argument("--enable_context_fmha", default=False, action="store_true")
     parser.add_argument(
-        '--output_dir',
+        "--enable_context_fmha_fp32_acc", default=False, action="store_true"
+    )
+    parser.add_argument("--visualize", default=False, action="store_true")
+    parser.add_argument("--enable_debug_output", default=False, action="store_true")
+    parser.add_argument("--gpus_per_node", type=int, default=8)
+    parser.add_argument("--builder_opt", type=int, default=None)
+    parser.add_argument(
+        "--output_dir",
         type=str,
         default=default_config.engine_dir,
-        help=
-        'The path to save the serialized engine files, timing cache file and model configs'
+        help="The path to save the serialized engine files, timing cache file and model configs",
     )
-    parser.add_argument(
-        '--remove_input_padding',
-        default=False,
-        action='store_true'
-    )
+    parser.add_argument("--remove_input_padding", default=False, action="store_true")
     # Arguments related to the quantization of the model.
     parser.add_argument(
-        '--use_smooth_quant',
+        "--use_smooth_quant",
         default=False,
         action="store_true",
-        help=
-        'Use the SmoothQuant method to quantize activations and weights for the various GEMMs.'
-        'See --per_channel and --per_token for finer-grained quantization options.'
+        help="Use the SmoothQuant method to quantize activations and weights for the various GEMMs."
+        "See --per_channel and --per_token for finer-grained quantization options.",
     )
     parser.add_argument(
-        '--per_channel',
+        "--per_channel",
         default=False,
         action="store_true",
-        help=
-        'By default, we use a single static scaling factor for the GEMM\'s result. '
-        'per_channel instead uses a different static scaling factor for each channel. '
-        'The latter is usually more accurate, but a little slower.')
+        help="By default, we use a single static scaling factor for the GEMM's result. "
+        "per_channel instead uses a different static scaling factor for each channel. "
+        "The latter is usually more accurate, but a little slower.",
+    )
     parser.add_argument(
-        '--per_token',
+        "--per_token",
         default=False,
         action="store_true",
-        help=
-        'By default, we use a single static scaling factor to scale activations in the int8 range. '
-        'per_token chooses at run time, and for each token, a custom scaling factor. '
-        'The latter is usually more accurate, but a little slower.')
-    
+        help="By default, we use a single static scaling factor to scale activations in the int8 range. "
+        "per_token chooses at run time, and for each token, a custom scaling factor. "
+        "The latter is usually more accurate, but a little slower.",
+    )
+
     parser.add_argument(
-        '--per_group',
+        "--per_group",
         default=False,
         action="store_true",
-        help=
-        'By default, we use a single static scaling factor to scale weights in the int4 range. '
-        'per_group chooses at run time, and for each group, a custom scaling factor. '
-        'The flag is built for GPTQ/AWQ quantization.')
+        help="By default, we use a single static scaling factor to scale weights in the int4 range. "
+        "per_group chooses at run time, and for each group, a custom scaling factor. "
+        "The flag is built for GPTQ/AWQ quantization.",
+    )
 
     parser.add_argument(
         "--add_plugins",
-        nargs='?',
+        nargs="?",
         type=str,
         default=os.path.join(
             now_dir, "plugins", "build", "librmsnorm_quantization_1.0.0.so"
         ),
-        help="add custom plugins, eg: --add_plugins xxx.so,yyy.so,zzz.so"
+        help="add custom plugins, eg: --add_plugins xxx.so,yyy.so,zzz.so",
     )
     parser.add_argument(
-        '--use_weight_only',
+        "--use_weight_only",
         default=False,
         action="store_true",
-        help='Quantize weights for the various GEMMs to INT4/INT8.'
-        'See --weight_only_precision to set the precision')
+        help="Quantize weights for the various GEMMs to INT4/INT8."
+        "See --weight_only_precision to set the precision",
+    )
 
     parser.add_argument(
-        '--weight_only_precision',
-        const='int8',
+        "--weight_only_precision",
+        const="int8",
         type=str,
-        nargs='?',
-        default='int8',
-        choices=['int8', 'int4'],
-        help=
-        'Define the precision for the weights when using weight-only quantization.'
-        'You must also use --use_weight_only for that argument to have an impact.'
+        nargs="?",
+        default="int8",
+        choices=["int8", "int4"],
+        help="Define the precision for the weights when using weight-only quantization."
+        "You must also use --use_weight_only for that argument to have an impact.",
     )
     parser.add_argument(
-        '--use_inflight_batching',
+        "--use_inflight_batching",
         action="store_true",
         default=False,
-        help="Activates inflight batching mode of gptAttentionPlugin.")
-    parser.add_argument(
-        '--paged_kv_cache',
-        action="store_true",
-        default=False,
-        help=
-        'By default we use contiguous KV cache. By setting this flag you enable paged KV cache'
+        help="Activates inflight batching mode of gptAttentionPlugin.",
     )
     parser.add_argument(
-        '--tokens_per_block',
+        "--paged_kv_cache",
+        action="store_true",
+        default=False,
+        help="By default we use contiguous KV cache. By setting this flag you enable paged KV cache",
+    )
+    parser.add_argument(
+        "--tokens_per_block",
         type=int,
         default=64,
-        help='Number of tokens per block in paged KV cache'
+        help="Number of tokens per block in paged KV cache",
     )
 
     parser.add_argument(
-        '--max_num_tokens',
+        "--max_num_tokens",
         type=int,
         default=None,
-        help='Define the max number of tokens supported by the engine')
-    
+        help="Define the max number of tokens supported by the engine",
+    )
+
     parser.add_argument(
-        '--int8_kv_cache',
+        "--int8_kv_cache",
         default=False,
         action="store_true",
-        help=
-        'By default, we use dtype for KV cache. int8_kv_cache chooses int8 quantization for KV'
+        help="By default, we use dtype for KV cache. int8_kv_cache chooses int8 quantization for KV",
     )
     parser.add_argument(
-        '--use_parallel_embedding',
+        "--use_parallel_embedding",
         action="store_true",
         default=False,
-        help=
-        'By default embedding parallelism is disabled. By setting this flag, embedding parallelism is enabled'
+        help="By default embedding parallelism is disabled. By setting this flag, embedding parallelism is enabled",
     )
     parser.add_argument(
-        '--embedding_sharding_dim',
+        "--embedding_sharding_dim",
         type=int,
         default=1,  # Meta does TP on hidden dim
         choices=[0, 1],
-        help=
-        'By default the embedding lookup table is sharded along vocab dimension (embedding_sharding_dim=0). '
-        'To shard it along hidden dimension, set embedding_sharding_dim=1'
-        'Note: embedding sharing is only enabled when embedding_sharding_dim = 0'
+        help="By default the embedding lookup table is sharded along vocab dimension (embedding_sharding_dim=0). "
+        "To shard it along hidden dimension, set embedding_sharding_dim=1"
+        "Note: embedding sharing is only enabled when embedding_sharding_dim = 0",
     )
     parser.add_argument(
-        '--enable_fp8',
-        default=False,
-        action='store_true',
-        help='Use FP8 Linear layer for Attention QKV/Dense and MLP.')
-    parser.add_argument(
-        '--fp8_kv_cache',
+        "--enable_fp8",
         default=False,
         action="store_true",
-        help=
-        'By default, we use dtype for KV cache. fp8_kv_cache chooses int8 quantization for KV'
+        help="Use FP8 Linear layer for Attention QKV/Dense and MLP.",
     )
     parser.add_argument(
-        '--strongly_typed',
+        "--fp8_kv_cache",
         default=False,
         action="store_true",
-        help=
-        'This option is introduced with trt 9.1.0.1+ and will reduce the building time significantly for fp8.'
+        help="By default, we use dtype for KV cache. fp8_kv_cache chooses int8 quantization for KV",
     )
     parser.add_argument(
-        '--use_custom_all_reduce',
-        action='store_true',
-        help=
-        'Activates latency-optimized algorithm for all-reduce instead of NCCL.')
+        "--strongly_typed",
+        default=False,
+        action="store_true",
+        help="This option is introduced with trt 9.1.0.1+ and will reduce the building time significantly for fp8.",
+    )
+    parser.add_argument(
+        "--use_custom_all_reduce",
+        action="store_true",
+        help="Activates latency-optimized algorithm for all-reduce instead of NCCL.",
+    )
 
     args = parser.parse_args()
     assert not (
@@ -361,21 +362,19 @@ def parse_arguments():
 
     if args.use_inflight_batching:
         if not args.use_gpt_attention_plugin:
-            args.use_gpt_attention_plugin = 'float16'
+            args.use_gpt_attention_plugin = "float16"
             logger.info(
                 f"Using GPT attention plugin for inflight batching mode. Setting to default '{args.use_gpt_attention_plugin}'"
             )
         if not args.remove_input_padding:
             args.remove_input_padding = True
-            logger.info(
-                "Using remove input padding for inflight batching mode.")
+            logger.info("Using remove input padding for inflight batching mode.")
         if not args.paged_kv_cache:
             args.paged_kv_cache = True
             logger.info("Using paged KV cache for inflight batching mode.")
 
     if args.use_smooth_quant:
-        args.quant_mode = QuantMode.use_smooth_quant(args.per_token,
-                                                     args.per_channel)
+        args.quant_mode = QuantMode.use_smooth_quant(args.per_token, args.per_channel)
     elif args.use_weight_only:
         if args.per_group:
             args.quant_mode = QuantMode.from_description(
@@ -384,13 +383,15 @@ def parse_arguments():
                 per_token=False,
                 per_channel=False,
                 per_group=True,
-                use_int4_weights=True)
+                use_int4_weights=True,
+            )
         else:
             args.quant_mode = QuantMode.use_weight_only(
-                args.weight_only_precision == 'int4')
+                args.weight_only_precision == "int4"
+            )
     else:
         args.quant_mode = QuantMode(0)
-    
+
     if args.int8_kv_cache:
         args.quant_mode = args.quant_mode.set_int8_kv_cache()
     # Since gpt_attenttion_plugin is the only way to apply RoPE now,
@@ -401,7 +402,9 @@ def parse_arguments():
             args.hf_model_dir,
             trust_remote_code=True,
         )
-        args.inter_size = hf_config.intermediate_size  # override the inter_size for QWen
+        args.inter_size = (
+            hf_config.intermediate_size
+        )  # override the inter_size for QWen
         args.n_embd = hf_config.hidden_size
         args.n_head = hf_config.num_attention_heads
         if hasattr(hf_config, "num_key_value_heads"):
@@ -412,15 +415,18 @@ def parse_arguments():
         args.hidden_act = "silu"
         args.kv_channels = hf_config.kv_channels
         args.rotary_emb_base = hf_config.rotary_emb_base
-    assert args.use_gpt_attention_plugin is not None, "QWen must use gpt attention plugin"
+    assert (
+        args.use_gpt_attention_plugin is not None
+    ), "QWen must use gpt attention plugin"
     if not args.use_gemm_plugin:
         print("wanring QWen should use gemm plugin")
     if args.n_kv_head is not None and args.n_kv_head != args.n_head:
-        assert args.n_kv_head == args.world_size, \
-        "The current implementation of GQA requires the number of K/V heads to match the number of GPUs." \
-        "This limitation will be removed in a future version."
+        assert args.n_kv_head == args.world_size, (
+            "The current implementation of GQA requires the number of K/V heads to match the number of GPUs."
+            "This limitation will be removed in a future version."
+        )
 
-    if args.dtype == 'bfloat16':
+    if args.dtype == "bfloat16":
         assert args.use_gemm_plugin, "Please use gemm plugin when dtype is bfloat16"
 
     assert args.pp_size * args.tp_size == args.world_size
@@ -431,26 +437,33 @@ def parse_arguments():
     return args
 
 
-def build_rank_engine(builder: Builder,
-                      builder_config: tensorrt_llm.builder.BuilderConfig,
-                      engine_name, rank, multi_query_mode, args):
-    '''
-       @brief: Build the engine on the given rank.
-       @param rank: The rank to build the engine.
-       @param args: The cmd line arguments.
-       @return: The built engine.
-    '''
+def build_rank_engine(
+    builder: Builder,
+    builder_config: tensorrt_llm.builder.BuilderConfig,
+    engine_name,
+    rank,
+    multi_query_mode,
+    args,
+):
+    """
+    @brief: Build the engine on the given rank.
+    @param rank: The rank to build the engine.
+    @param args: The cmd line arguments.
+    @return: The built engine.
+    """
     kv_dtype = str_dtype_to_trt(args.dtype)
-    mapping = Mapping(world_size=args.world_size,
-                      rank=rank,
-                      tp_size=args.tp_size,
-                      pp_size=args.pp_size)
+    mapping = Mapping(
+        world_size=args.world_size,
+        rank=rank,
+        tp_size=args.tp_size,
+        pp_size=args.pp_size,
+    )
     # load custom plugins
     custom_plugin_paths = [
         plugin_path
         for plugin_path in args.add_plugins.split(",")
         if os.path.exists(plugin_path)
-    ] 
+    ]
     if len(custom_plugin_paths) > 0:
         trt.init_libnvinfer_plugins(tensorrt_llm.logger, "")
         for custom_plugin_path in custom_plugin_paths:
@@ -475,9 +488,9 @@ def build_rank_engine(builder: Builder,
         use_parallel_embedding=args.use_parallel_embedding,
         embedding_sharding_dim=args.embedding_sharding_dim,
         quant_mode=args.quant_mode,
-        custom_plugin_paths=custom_plugin_paths
+        custom_plugin_paths=custom_plugin_paths,
     )
-    
+
     if args.use_smooth_quant:
         if not args.per_token:
             print("warning per_channel should be set when using smooth quantize")
@@ -486,32 +499,32 @@ def build_rank_engine(builder: Builder,
         tensorrt_llm_qwen = smooth_quantize(
             tensorrt_llm_qwen,
             args.quant_mode,
-            args.dtype, 
+            args.dtype,
             custom_plugin_paths,
         )
         print("load smooth quantize ok")
     elif args.use_weight_only:
-        if args.weight_only_precision == 'int8':
-            tensorrt_llm_qwen = weight_only_quantize(tensorrt_llm_qwen,
-                                                      args.quant_mode)
-        elif args.weight_only_precision == 'int4':
-            tensorrt_llm_qwen = weight_only_quantize(tensorrt_llm_qwen,
-                                                      args.quant_mode)
-        elif args.weight_only_precision == 'int4_awq':
+        if args.weight_only_precision == "int8":
+            tensorrt_llm_qwen = weight_only_quantize(tensorrt_llm_qwen, args.quant_mode)
+        elif args.weight_only_precision == "int4":
+            tensorrt_llm_qwen = weight_only_quantize(tensorrt_llm_qwen, args.quant_mode)
+        elif args.weight_only_precision == "int4_awq":
             tensorrt_llm_qwen = weight_only_groupwise_quantize(
                 model=tensorrt_llm_qwen,
                 quant_mode=args.quant_mode,
                 group_size=args.group_size,
                 zero=False,
                 pre_quant_scale=True,
-                exclude_modules=[])
-        elif args.weight_only_precision == 'int4_gptq':
+                exclude_modules=[],
+            )
+        elif args.weight_only_precision == "int4_gptq":
             tensorrt_llm_qwen = weight_only_groupwise_quantize(
                 model=tensorrt_llm_qwen,
                 quant_mode=args.quant_mode,
                 group_size=args.group_size,
                 zero=True,
-                pre_quant_scale=False)
+                pre_quant_scale=False,
+            )
         # elif args.enable_fp8 or args.fp8_kv_cache:
         #     logger.info(f'Loading scaling factors from '
         #                 f'{args.quantized_fp8_model_path}')
@@ -525,51 +538,53 @@ def build_rank_engine(builder: Builder,
         ft_dir_path = os.path.join(args.ft_dir_path, str(args.tp_size) + "-gpu")
     else:
         ft_dir_path = args.ft_dir_path
-    if args.hf_model_dir is not None and \
-        (ft_dir_path is None or not os.path.exists(ft_dir_path)):
-        print("\033[33m", ft_dir_path, "not exists, will get weight from qwen local", "\033[0m")
-        logger.info(f'Loading HF QWen ... from {args.hf_model_dir}')
+    if args.hf_model_dir is not None and (
+        ft_dir_path is None or not os.path.exists(ft_dir_path)
+    ):
+        print(
+            "\033[33m",
+            ft_dir_path,
+            "not exists, will get weight from qwen local",
+            "\033[0m",
+        )
+        logger.info(f"Loading HF QWen ... from {args.hf_model_dir}")
         tik = time.time()
         hf_qwen = AutoModelForCausalLM.from_pretrained(
             args.hf_model_dir,
-            device_map={
-                "transformer": "cpu",
-                "lm_head": "cpu"
-            },  # Load to CPU memory
+            device_map={"transformer": "cpu", "lm_head": "cpu"},  # Load to CPU memory
             torch_dtype="auto",
             trust_remote_code=True,
         )
         tok = time.time()
-        t = time.strftime('%H:%M:%S', time.gmtime(tok - tik))
-        logger.info(f'HF QWen loaded. Total time: {t}')
+        t = time.strftime("%H:%M:%S", time.gmtime(tok - tik))
+        logger.info(f"HF QWen loaded. Total time: {t}")
         load_from_hf_qwen(
             tensorrt_llm_qwen,
             hf_qwen,
             mapping,
-            #rank,
-            #args.world_size,
+            # rank,
+            # args.world_size,
             max_position_embeddings=args.n_positions,
             kv_channels=args.kv_channels,
             rotary_emb_base=args.rotary_emb_base,
             dtype=args.dtype,
-            multi_query_mode=multi_query_mode
+            multi_query_mode=multi_query_mode,
         )
         del hf_qwen
     elif ft_dir_path is not None:
         dir_path = ft_dir_path
-        logger.info(f'Loading FT QWen ... from {ft_dir_path}')
+        logger.info(f"Loading FT QWen ... from {ft_dir_path}")
         load_from_ft(
             tensorrt_llm_qwen,
             dir_path,
             mapping,
-            #rank,
-            #args.world_size,
+            # rank,
+            # args.world_size,
             dtype=args.dtype,
-            multi_query_mode=multi_query_mode
+            multi_query_mode=multi_query_mode,
         )
     else:
-        raise ValueError(
-            "You must specify either --hf_model_dir or --ft_dir_path")
+        raise ValueError("You must specify either --hf_model_dir or --ft_dir_path")
 
     # Module -> Network
     network = builder.create_network()
@@ -581,9 +596,7 @@ def build_rank_engine(builder: Builder,
     if args.use_gemm_plugin:
         network.plugin_config.set_gemm_plugin(dtype=args.use_gemm_plugin)
     if args.use_weight_only:
-        network.plugin_config.set_weight_only_quant_matmul_plugin(
-            dtype='float16'
-        )
+        network.plugin_config.set_weight_only_quant_matmul_plugin(dtype="float16")
     # Quantization plugins.
     if args.use_smooth_quant:
         network.plugin_config.set_smooth_quant_gemm_plugin(dtype=args.dtype)
@@ -596,21 +609,19 @@ def build_rank_engine(builder: Builder,
     if args.enable_context_fmha:
         network.plugin_config.set_context_fmha(ContextFMHAType.enabled)
     if args.enable_context_fmha_fp32_acc:
-        network.plugin_config.set_context_fmha(
-            ContextFMHAType.enabled_with_fp32_acc)
+        network.plugin_config.set_context_fmha(ContextFMHAType.enabled_with_fp32_acc)
     if args.use_weight_only:
         if args.per_group:
             network.plugin_config.set_weight_only_groupwise_quant_matmul_plugin(
-                dtype='float16')
+                dtype="float16"
+            )
         else:
-            network.plugin_config.set_weight_only_quant_matmul_plugin(
-                dtype='float16')
+            network.plugin_config.set_weight_only_quant_matmul_plugin(dtype="float16")
     if args.world_size > 1:
-        network.plugin_config.set_nccl_plugin(args.dtype,
-                                              args.use_custom_all_reduce)
+        network.plugin_config.set_nccl_plugin(args.dtype, args.use_custom_all_reduce)
     if args.remove_input_padding:
         network.plugin_config.enable_remove_input_padding()
-    
+
     if args.paged_kv_cache:
         network.plugin_config.enable_paged_kv_cache(args.tokens_per_block)
 
@@ -636,7 +647,7 @@ def build_rank_engine(builder: Builder,
                 network.trt_network.mark_output(v)
                 v.dtype = kv_dtype
         if args.visualize:
-            model_path = os.path.join(args.output_dir, 'test.onnx')
+            model_path = os.path.join(args.output_dir, "test.onnx")
             to_onnx(network.trt_network, model_path)
 
     engine = None
@@ -644,7 +655,7 @@ def build_rank_engine(builder: Builder,
     # Network -> Engine
     engine = builder.build_engine(network, builder_config)
     if rank == 0:
-        config_path = os.path.join(args.output_dir, 'config.json')
+        config_path = os.path.join(args.output_dir, "config.json")
         builder.save_config(builder_config, config_path)
     return engine
 
@@ -654,8 +665,7 @@ def build(rank, args):
     tensorrt_llm.logger.set_level(args.log_level)
     if not os.path.exists(args.output_dir):
         os.makedirs(args.output_dir)
-    multi_query_mode = (args.n_kv_head
-                        is not None) and (args.n_kv_head != args.n_head)
+    multi_query_mode = (args.n_kv_head is not None) and (args.n_kv_head != args.n_head)
 
     # when doing serializing build, all ranks share one engine
     builder = Builder()
@@ -666,7 +676,8 @@ def build(rank, args):
         if args.parallel_build and cur_rank != rank:
             continue
         int8_trt_flag = args.quant_mode.has_act_and_weight_quant() or (
-            not args.paged_kv_cache and args.quant_mode.has_int8_kv_cache())
+            not args.paged_kv_cache and args.quant_mode.has_int8_kv_cache()
+        )
         builder_config = builder.create_builder_config(
             name=MODEL_NAME,
             precision=args.dtype,
@@ -688,13 +699,15 @@ def build(rank, args):
             fp8=args.quant_mode.has_fp8_qdq(),
             quant_mode=args.quant_mode,
             strongly_typed=args.strongly_typed,
-            opt_level=args.builder_opt
+            opt_level=args.builder_opt,
         )
-        engine_name = get_engine_name(MODEL_NAME, args.dtype, args.tp_size, args.pp_size, 
-                                      cur_rank)
-        engine = build_rank_engine(builder, builder_config, engine_name,
-                                   cur_rank, multi_query_mode, args)
-        assert engine is not None, f'Failed to build engine for rank {cur_rank}'
+        engine_name = get_engine_name(
+            MODEL_NAME, args.dtype, args.tp_size, args.pp_size, cur_rank
+        )
+        engine = build_rank_engine(
+            builder, builder_config, engine_name, cur_rank, multi_query_mode, args
+        )
+        assert engine is not None, f"Failed to build engine for rank {cur_rank}"
 
         if cur_rank == 0:
             # Use in-memory timing cache for multiple builder passes.
@@ -705,25 +718,29 @@ def build(rank, args):
 
     if rank == 0:
         ok = builder.save_timing_cache(
-            builder_config, os.path.join(args.output_dir, "model.cache"))
+            builder_config, os.path.join(args.output_dir, "model.cache")
+        )
         assert ok, "Failed to save timing cache."
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     args = parse_arguments()
     logger.set_level(args.log_level)
     tik = time.time()
-    if args.parallel_build and args.world_size > 1 and \
-            torch.cuda.device_count() >= args.world_size:
+    if (
+        args.parallel_build
+        and args.world_size > 1
+        and torch.cuda.device_count() >= args.world_size
+    ):
         logger.warning(
-            f'Parallelly build TensorRT engines. Please make sure that all of the {args.world_size} GPUs are totally free.'
+            f"Parallelly build TensorRT engines. Please make sure that all of the {args.world_size} GPUs are totally free."
         )
-        mp.spawn(build, nprocs=args.world_size, args=(args, ))
+        mp.spawn(build, nprocs=args.world_size, args=(args,))
     else:
         args.parallel_build = False
-        logger.info('Serially build TensorRT engines.')
+        logger.info("Serially build TensorRT engines.")
         build(0, args)
 
     tok = time.time()
-    t = time.strftime('%H:%M:%S', time.gmtime(tok - tik))
-    logger.info(f'Total time of building all {args.world_size} engines: {t}')
+    t = time.strftime("%H:%M:%S", time.gmtime(tok - tik))
+    logger.info(f"Total time of building all {args.world_size} engines: {t}")

--- a/qwen/weight.py
+++ b/qwen/weight.py
@@ -7,10 +7,16 @@ import numpy as np
 import torch
 from tqdm import tqdm
 import tensorrt_llm
-from tensorrt_llm._utils import str_dtype_to_torch, str_dtype_to_np, pad_vocab_size, torch_to_numpy
+from tensorrt_llm._utils import (
+    str_dtype_to_torch,
+    str_dtype_to_np,
+    pad_vocab_size,
+    torch_to_numpy,
+)
 from tensorrt_llm.quantization import QuantMode
 from model import QWenForCausalLM
 from tensorrt_llm.mapping import Mapping
+
 
 def gen_suffix(rank, use_smooth_quant, quant_per_channel):
     suffix = f"{rank}.bin"
@@ -21,8 +27,9 @@ def gen_suffix(rank, use_smooth_quant, quant_per_channel):
         suffix = sq_prefix + suffix
     return suffix
 
+
 def extract_layer_idx(name):
-    ss = name.split('.')
+    ss = name.split(".")
     for s in ss:
         if s.isdigit():
             return s
@@ -37,29 +44,27 @@ def split(v, tp_size, idx, dim=0):
     else:
         return np.ascontiguousarray(np.split(v, tp_size, axis=dim)[idx])
 
+
 def parse_ft_config(ini_file):
     qwen_config = configparser.ConfigParser()
     qwen_config.read(ini_file)
 
-    vocab_size = qwen_config.getint('qwen', 'vocab_size')
-    hidden_size = qwen_config.getint('qwen', 'hidden_size')
-    inter_size = qwen_config.getint('qwen', 'intermediate_size', fallback=None)
+    vocab_size = qwen_config.getint("qwen", "vocab_size")
+    hidden_size = qwen_config.getint("qwen", "hidden_size")
+    inter_size = qwen_config.getint("qwen", "intermediate_size", fallback=None)
     num_hidden_layers = qwen_config.getint(
         "qwen",
         "num_hidden_layers",
         fallback=32,
     )
     max_position_embeddings = qwen_config.getint(
-        "qwen", "max_position_embeddings", fallback=8192)
-    kv_channels = qwen_config.getint('qwen', 'kv_channels', fallback=128)
-    rotary_pct = qwen_config.getfloat('qwen', 'rotary_pct', fallback=0.0)
-    rotary_emb_base = qwen_config.getint(
-        'qwen', 'rotary_emb_base', fallback=10000
+        "qwen", "max_position_embeddings", fallback=8192
     )
+    kv_channels = qwen_config.getint("qwen", "kv_channels", fallback=128)
+    rotary_pct = qwen_config.getfloat("qwen", "rotary_pct", fallback=0.0)
+    rotary_emb_base = qwen_config.getint("qwen", "rotary_emb_base", fallback=10000)
     multi_query_mode = qwen_config.getboolean(
-        'qwen',
-        'multi_query_mode',
-        fallback=False
+        "qwen", "multi_query_mode", fallback=False
     )
     return (
         vocab_size,
@@ -70,21 +75,24 @@ def parse_ft_config(ini_file):
         rotary_pct,
         rotary_emb_base,
         multi_query_mode,
-        max_position_embeddings
+        max_position_embeddings,
     )
 
-def load_from_ft(tensorrt_llm_qwen: QWenForCausalLM,
-                 dir_path,
-                 mapping=Mapping(),
-                 #rank=0,
-                 #tensor_parallel=1,
-                 dtype='float16',
-                 share_embedding_table=False,
-                 parallel_embedding_table=False,
-                 multi_query_mode=False):
-    tensorrt_llm.logger.info('Loading weights from FT...')
+
+def load_from_ft(
+    tensorrt_llm_qwen: QWenForCausalLM,
+    dir_path,
+    mapping=Mapping(),
+    # rank=0,
+    # tensor_parallel=1,
+    dtype="float16",
+    share_embedding_table=False,
+    parallel_embedding_table=False,
+    multi_query_mode=False,
+):
+    tensorrt_llm.logger.info("Loading weights from FT...")
     tik = time.time()
-    quant_mode = getattr(tensorrt_llm_qwen, 'quant_mode', QuantMode(0))
+    quant_mode = getattr(tensorrt_llm_qwen, "quant_mode", QuantMode(0))
     if quant_mode.is_int8_weight_only():
         plugin_weight_only_quant_type = torch.int8
     elif quant_mode.is_int4_weight_only():
@@ -98,14 +106,13 @@ def load_from_ft(tensorrt_llm_qwen: QWenForCausalLM,
         rotary_pct,
         rotary_emb_base,
         multi_query_mode,
-        max_position_embeddings
-    ) = parse_ft_config(
-        Path(dir_path) / 'config.ini')
+        max_position_embeddings,
+    ) = parse_ft_config(Path(dir_path) / "config.ini")
     np_dtype = str_dtype_to_np(dtype)
 
     def fromfile(dir_path, name, shape=None, dtype=np.float16):
         dtype = np_dtype if dtype is None else dtype
-        p = dir_path + '/' + name
+        p = dir_path + "/" + name
         if Path(p).exists():
             t = np.fromfile(p, dtype=dtype)
             if shape is not None:
@@ -137,23 +144,31 @@ def load_from_ft(tensorrt_llm_qwen: QWenForCausalLM,
             # print(f"{basename}scale_w_quant_orig.{suffix}")
             if pre_scale_weight is not None:
                 pre_scale_weight.value = np.array([1.0], dtype=np.float32)
-            t = fromfile(dir_path, f"{basename}scale_w_quant_orig.{suffix}",
-                         col_shape, np.float32)
+            t = fromfile(
+                dir_path,
+                f"{basename}scale_w_quant_orig.{suffix}",
+                col_shape,
+                np.float32,
+            )
             module.per_channel_scale.value = t
         else:
-            t = fromfile(dir_path, f"{basename}scale_x_orig_quant.bin", [1],
-                         np.float32)
+            t = fromfile(dir_path, f"{basename}scale_x_orig_quant.bin", [1], np.float32)
             pre_scale_weight.value = t
-            t = fromfile(dir_path, f"{basename}scale_y_accum_quant.{suffix}",
-                         col_shape, np.float32)
+            t = fromfile(
+                dir_path,
+                f"{basename}scale_y_accum_quant.{suffix}",
+                col_shape,
+                np.float32,
+            )
             module.per_channel_scale.value = t
-            t = fromfile(dir_path, f"{basename}scale_y_quant_orig.bin", [1, 1],
-                         np.float32)
+            t = fromfile(
+                dir_path, f"{basename}scale_y_quant_orig.bin", [1, 1], np.float32
+            )
             module.act_scale.value = t
+
     def set_smoother(module, dir_path, base_name, shape, rank):
         suffix = f"{rank}.bin"
-        t = fromfile(dir_path, f"{base_name}.smoother.{suffix}", shape,
-                     np.float32)
+        t = fromfile(dir_path, f"{base_name}.smoother.{suffix}", shape, np.float32)
         module.smoother.value = t
 
     # Determine the quantization mode.
@@ -180,12 +195,12 @@ def load_from_ft(tensorrt_llm_qwen: QWenForCausalLM,
     w_type = np_dtype if not use_smooth_quant else np.int8
 
     if mapping.is_first_pp_rank():
-        tensorrt_llm_qwen.vocab_embedding.weight.value = (fromfile(
-            dir_path, 'vocab_embedding.weight.bin', [vocab_size, hidden_size]))
+        tensorrt_llm_qwen.vocab_embedding.weight.value = fromfile(
+            dir_path, "vocab_embedding.weight.bin", [vocab_size, hidden_size]
+        )
 
     if mapping.is_last_pp_rank():
-        tensorrt_llm_qwen.ln_f.weight.value = (fromfile(
-            dir_path, 'ln_f.weight.bin'))
+        tensorrt_llm_qwen.ln_f.weight.value = fromfile(dir_path, "ln_f.weight.bin")
 
     # pe = fromfile(dir_path, 'model.wpe.bin', [n_positions, n_embd])
     # if pe is not None:
@@ -206,66 +221,76 @@ def load_from_ft(tensorrt_llm_qwen: QWenForCausalLM,
 
     # breakpoint()
 
-    lm_head_weight = fromfile(dir_path, 'lm_head.weight.bin',
-                              [vocab_size, hidden_size])
+    lm_head_weight = fromfile(dir_path, "lm_head.weight.bin", [vocab_size, hidden_size])
 
     if vocab_size % mapping.tp_size != 0:
         # padding
         vocab_size_padded = tensorrt_llm_qwen.lm_head.out_features * mapping.tp_size
         pad_width = vocab_size_padded - vocab_size
-        lm_head_weight = np.pad(lm_head_weight, ((0, pad_width), (0, 0)),
-                                'constant',
-                                constant_values=0)
+        lm_head_weight = np.pad(
+            lm_head_weight, ((0, pad_width), (0, 0)), "constant", constant_values=0
+        )
     if mapping.is_last_pp_rank():
         tensorrt_llm_qwen.lm_head.weight.value = np.ascontiguousarray(
-            split(lm_head_weight, mapping.tp_size, mapping.tp_rank))
+            split(lm_head_weight, mapping.tp_size, mapping.tp_rank)
+        )
 
     layers_range = list(
-        range(mapping.pp_rank * tensorrt_llm_qwen.num_layers,
-              (mapping.pp_rank + 1) * tensorrt_llm_qwen.num_layers, 1))
+        range(
+            mapping.pp_rank * tensorrt_llm_qwen.num_layers,
+            (mapping.pp_rank + 1) * tensorrt_llm_qwen.num_layers,
+            1,
+        )
+    )
 
     for i in layers_range:
-        c_attn_out_dim = (3 * hidden_size //
-                          mapping.tp_size) if not multi_query_mode else (
-                              hidden_size // mapping.tp_size +
-                              (hidden_size // num_hidden_layers) * 2)
+        c_attn_out_dim = (
+            (3 * hidden_size // mapping.tp_size)
+            if not multi_query_mode
+            else (
+                hidden_size // mapping.tp_size + (hidden_size // num_hidden_layers) * 2
+            )
+        )
 
         tensorrt_llm_qwen.layers[i].ln_1.weight.value = fromfile(
-            dir_path, 'model.layers.' + str(i) + '.ln_1.weight.bin'
+            dir_path, "model.layers." + str(i) + ".ln_1.weight.bin"
         )
 
         dst = tensorrt_llm_qwen.layers[i].ln_2.weight
-        dst.value = fromfile(
-            dir_path, 'model.layers.' + str(i) + '.ln_2.weight.bin')
+        dst.value = fromfile(dir_path, "model.layers." + str(i) + ".ln_2.weight.bin")
 
         t = fromfile(
-            dir_path, 'model.layers.' + str(i) + '.attention.qkv.weight.' + suffix,
+            dir_path,
+            "model.layers." + str(i) + ".attention.qkv.weight." + suffix,
             [hidden_size, c_attn_out_dim],
-            w_type
+            w_type,
         )
-        #breakpoint()
+        # breakpoint()
         if t is not None:
             dst = tensorrt_llm_qwen.layers[i].attention.qkv.weight
             if use_smooth_quant:
-                dst.value = sq_trick(
-                    np.ascontiguousarray(np.transpose(t, [1, 0])))
+                dst.value = sq_trick(np.ascontiguousarray(np.transpose(t, [1, 0])))
                 set_smoothquant_scale_factors(
                     tensorrt_llm_qwen.layers[i].attention.qkv,
                     tensorrt_llm_qwen.layers[i].ln_1.scale_to_int,
                     dir_path,
-                    'model.layers.' + str(i) + '.attention.qkv.',
+                    "model.layers." + str(i) + ".attention.qkv.",
                     [1, c_attn_out_dim],
                     quant_per_token_dyn,
                     quant_per_channel,
                     rank=mapping.rank,
-                    is_qkv=True)
+                    is_qkv=True,
+                )
             elif use_weight_only:
                 # t = np.ascontiguousarray(np.transpose(t, [1, 0]))
-                processed_torch_weights, torch_weight_scales = torch.ops.fastertransformer.symmetric_quantize_last_axis_of_batched_matrix(
-                    torch.tensor(t), plugin_weight_only_quant_type)
+                (
+                    processed_torch_weights,
+                    torch_weight_scales,
+                ) = torch.ops.fastertransformer.symmetric_quantize_last_axis_of_batched_matrix(
+                    torch.tensor(t), plugin_weight_only_quant_type
+                )
                 # workaround for trt not supporting int8 inputs in plugins currently
-                dst.value = processed_torch_weights.view(
-                    dtype=torch.float32).numpy()
+                dst.value = processed_torch_weights.view(dtype=torch.float32).numpy()
                 scales = tensorrt_llm_qwen.layers[i].attention.qkv.per_channel_scale
                 scales.value = torch_weight_scales.numpy()
             else:
@@ -273,22 +298,35 @@ def load_from_ft(tensorrt_llm_qwen: QWenForCausalLM,
 
         dst = tensorrt_llm_qwen.layers[i].attention.qkv.bias
         t = fromfile(
-            dir_path, 'model.layers.' + str(i) +
-            '.attention.qkv.bias.' + str(mapping.rank) + '.bin', [c_attn_out_dim])
+            dir_path,
+            "model.layers."
+            + str(i)
+            + ".attention.qkv.bias."
+            + str(mapping.rank)
+            + ".bin",
+            [c_attn_out_dim],
+        )
         dst.value = np.ascontiguousarray(t)
 
         dst = tensorrt_llm_qwen.layers[i].attention.dense.weight
         t = fromfile(
             dir_path,
-            'model.layers.' + str(i) + '.attention.dense.weight.' + suffix,
-            [hidden_size // mapping.tp_size, hidden_size], w_type)
+            "model.layers." + str(i) + ".attention.dense.weight." + suffix,
+            [hidden_size // mapping.tp_size, hidden_size],
+            w_type,
+        )
         if use_smooth_quant:
             dst.value = sq_trick(np.ascontiguousarray(np.transpose(t, [1, 0])))
-            dense_scale = getattr(tensorrt_llm_qwen.layers[i].attention,
-                                  "quantization_scaling_factor", None)
+            dense_scale = getattr(
+                tensorrt_llm_qwen.layers[i].attention,
+                "quantization_scaling_factor",
+                None,
+            )
             set_smoothquant_scale_factors(
-                tensorrt_llm_qwen.layers[i].attention.dense, dense_scale,
-                dir_path, 'model.layers.' + str(i) + '.attention.dense.',
+                tensorrt_llm_qwen.layers[i].attention.dense,
+                dense_scale,
+                dir_path,
+                "model.layers." + str(i) + ".attention.dense.",
                 [1, hidden_size],
                 quant_per_token_dyn,
                 quant_per_channel,
@@ -296,17 +334,21 @@ def load_from_ft(tensorrt_llm_qwen: QWenForCausalLM,
             set_smoother(
                 tensorrt_llm_qwen.layers[i].attention.dense,
                 dir_path,
-                'model.layers.' + str(i) + '.attention.dense',
-                [1, hidden_size // mapping.tp_size], mapping.rank
+                "model.layers." + str(i) + ".attention.dense",
+                [1, hidden_size // mapping.tp_size],
+                mapping.rank,
             )
-            
+
         elif use_weight_only:
             # t = np.ascontiguousarray(np.transpose(t, [1, 0]))
-            processed_torch_weights, torch_weight_scales = torch.ops.fastertransformer.symmetric_quantize_last_axis_of_batched_matrix(
-                torch.tensor(t), plugin_weight_only_quant_type)
+            (
+                processed_torch_weights,
+                torch_weight_scales,
+            ) = torch.ops.fastertransformer.symmetric_quantize_last_axis_of_batched_matrix(
+                torch.tensor(t), plugin_weight_only_quant_type
+            )
             # workaround for trt not supporting int8 inputs in plugins currently
-            dst.value = processed_torch_weights.view(
-                dtype=torch.float32).numpy()
+            dst.value = processed_torch_weights.view(dtype=torch.float32).numpy()
             scales = tensorrt_llm_qwen.layers[i].attention.dense.per_channel_scale
             scales.value = torch_weight_scales.numpy()
         else:
@@ -314,128 +356,158 @@ def load_from_ft(tensorrt_llm_qwen: QWenForCausalLM,
 
         t = fromfile(
             dir_path,
-            'model.layers.' + str(i) + '.mlp.w1.weight.' + suffix,
+            "model.layers." + str(i) + ".mlp.w1.weight." + suffix,
             [hidden_size, inter_size // mapping.tp_size // 2],
-            w_type
+            w_type,
         )
         if use_smooth_quant:
             tensorrt_llm_qwen.layers[i].mlp.w1.weight.value = sq_trick(
-                np.ascontiguousarray(np.transpose(t, [1, 0])))
+                np.ascontiguousarray(np.transpose(t, [1, 0]))
+            )
             set_smoothquant_scale_factors(
                 tensorrt_llm_qwen.layers[i].mlp.w1,
                 tensorrt_llm_qwen.layers[i].ln_2.scale_to_int,
                 dir_path,
-                'model.layers.' + str(i) + '.mlp.w1.',
-                [1, inter_size // mapping.tp_size//2],
+                "model.layers." + str(i) + ".mlp.w1.",
+                [1, inter_size // mapping.tp_size // 2],
                 quant_per_token_dyn,
                 quant_per_channel,
-                rank=mapping.rank
+                rank=mapping.rank,
             )
         elif use_weight_only:
             dst = tensorrt_llm_qwen.layers[i].mlp.w1.weight
             # t = np.ascontiguousarray(np.transpose(t, [1, 0]))
-            processed_torch_weights, torch_weight_scales = torch.ops.fastertransformer.symmetric_quantize_last_axis_of_batched_matrix(
-                torch.tensor(t), plugin_weight_only_quant_type)
+            (
+                processed_torch_weights,
+                torch_weight_scales,
+            ) = torch.ops.fastertransformer.symmetric_quantize_last_axis_of_batched_matrix(
+                torch.tensor(t), plugin_weight_only_quant_type
+            )
             # workaround for trt not supporting int8 inputs in plugins currently
-            dst.value = processed_torch_weights.view(
-                dtype=torch.float32).numpy()
+            dst.value = processed_torch_weights.view(dtype=torch.float32).numpy()
             scales = tensorrt_llm_qwen.layers[i].mlp.w1.per_channel_scale
             scales.value = torch_weight_scales.numpy()
         else:
-            tensorrt_llm_qwen.layers[i].mlp.w1.weight.value = np.ascontiguousarray(np.transpose(t, [1, 0]))
+            tensorrt_llm_qwen.layers[i].mlp.w1.weight.value = np.ascontiguousarray(
+                np.transpose(t, [1, 0])
+            )
 
         t = fromfile(
             dir_path,
-            'model.layers.' + str(i) + '.mlp.w2.weight.' + suffix,
-            [hidden_size, inter_size // mapping.tp_size//2], w_type)
+            "model.layers." + str(i) + ".mlp.w2.weight." + suffix,
+            [hidden_size, inter_size // mapping.tp_size // 2],
+            w_type,
+        )
         if use_smooth_quant:
             tensorrt_llm_qwen.layers[i].mlp.w2.weight.value = sq_trick(
-                np.ascontiguousarray(np.transpose(t, [1, 0])))
+                np.ascontiguousarray(np.transpose(t, [1, 0]))
+            )
             set_smoothquant_scale_factors(
                 tensorrt_llm_qwen.layers[i].mlp.w2,
                 tensorrt_llm_qwen.layers[i].ln_2.scale_to_int,
                 dir_path,
-                'model.layers.' + str(i) + '.mlp.w2.',
-                [1, inter_size // mapping.tp_size//2],
+                "model.layers." + str(i) + ".mlp.w2.",
+                [1, inter_size // mapping.tp_size // 2],
                 quant_per_token_dyn,
                 quant_per_channel,
-                rank=mapping.rank
+                rank=mapping.rank,
             )
         elif use_weight_only:
             dst = tensorrt_llm_qwen.layers[i].mlp.w2.weight
             # t = np.ascontiguousarray(np.transpose(t, [1, 0]))
-            processed_torch_weights, torch_weight_scales = torch.ops.fastertransformer.symmetric_quantize_last_axis_of_batched_matrix(
-                torch.tensor(t), plugin_weight_only_quant_type)
+            (
+                processed_torch_weights,
+                torch_weight_scales,
+            ) = torch.ops.fastertransformer.symmetric_quantize_last_axis_of_batched_matrix(
+                torch.tensor(t), plugin_weight_only_quant_type
+            )
             # workaround for trt not supporting int8 inputs in plugins currently
-            dst.value = processed_torch_weights.view(
-                dtype=torch.float32).numpy()
+            dst.value = processed_torch_weights.view(dtype=torch.float32).numpy()
             scales = tensorrt_llm_qwen.layers[i].mlp.w2.per_channel_scale
             scales.value = torch_weight_scales.numpy()
         else:
-            tensorrt_llm_qwen.layers[i].mlp.w2.weight.value = np.ascontiguousarray(np.transpose(t, [1, 0]))
+            tensorrt_llm_qwen.layers[i].mlp.w2.weight.value = np.ascontiguousarray(
+                np.transpose(t, [1, 0])
+            )
 
         t = fromfile(
             dir_path,
-            'model.layers.' + str(i) + '.mlp.c_proj.weight.' + suffix,
+            "model.layers." + str(i) + ".mlp.c_proj.weight." + suffix,
             [inter_size // mapping.tp_size // 2, hidden_size],
-            w_type
+            w_type,
         )
         if use_smooth_quant:
             tensorrt_llm_qwen.layers[i].mlp.c_proj.weight.value = sq_trick(
-                np.ascontiguousarray(np.transpose(t, [1, 0])))
-            proj_scale = getattr(tensorrt_llm_qwen.layers[i].mlp,
-                                 "quantization_scaling_factor", None)
+                np.ascontiguousarray(np.transpose(t, [1, 0]))
+            )
+            proj_scale = getattr(
+                tensorrt_llm_qwen.layers[i].mlp, "quantization_scaling_factor", None
+            )
             set_smoothquant_scale_factors(
-                tensorrt_llm_qwen.layers[i].mlp.c_proj, proj_scale, dir_path,
-                'model.layers.' + str(i) + '.mlp.c_proj.', [1, hidden_size],
-                quant_per_token_dyn, quant_per_channel)
+                tensorrt_llm_qwen.layers[i].mlp.c_proj,
+                proj_scale,
+                dir_path,
+                "model.layers." + str(i) + ".mlp.c_proj.",
+                [1, hidden_size],
+                quant_per_token_dyn,
+                quant_per_channel,
+            )
             set_smoother(
                 tensorrt_llm_qwen.layers[i].mlp.c_proj,
                 dir_path,
-                'model.layers.' + str(i) + '.mlp.c_proj',
-                [1, inter_size // mapping.tp_size // 2], mapping.rank
+                "model.layers." + str(i) + ".mlp.c_proj",
+                [1, inter_size // mapping.tp_size // 2],
+                mapping.rank,
             )
         elif use_weight_only:
             dst = tensorrt_llm_qwen.layers[i].mlp.c_proj.weight
             # t = np.ascontiguousarray(np.transpose(t, [1, 0]))
-            processed_torch_weights, torch_weight_scales = torch.ops.fastertransformer.symmetric_quantize_last_axis_of_batched_matrix(
-                torch.tensor(t), plugin_weight_only_quant_type)
+            (
+                processed_torch_weights,
+                torch_weight_scales,
+            ) = torch.ops.fastertransformer.symmetric_quantize_last_axis_of_batched_matrix(
+                torch.tensor(t), plugin_weight_only_quant_type
+            )
             # workaround for trt not supporting int8 inputs in plugins currently
-            dst.value = processed_torch_weights.view(
-                dtype=torch.float32).numpy()
+            dst.value = processed_torch_weights.view(dtype=torch.float32).numpy()
             scales = tensorrt_llm_qwen.layers[i].mlp.c_proj.per_channel_scale
             scales.value = torch_weight_scales.numpy()
         else:
-            tensorrt_llm_qwen.layers[i].mlp.c_proj.weight.value = np.ascontiguousarray(np.transpose(t, [1, 0]))
+            tensorrt_llm_qwen.layers[i].mlp.c_proj.weight.value = np.ascontiguousarray(
+                np.transpose(t, [1, 0])
+            )
 
         if use_int8_kv_cache:
             t = fromfile(
-                dir_path, 'model.layers.' + str(i) +
-                '.attention.qkv.scale_y_quant_orig.bin', [1],
-                np.float32)
-            tensorrt_llm_qwen.layers[
-                i].attention.kv_orig_quant_scale.value = 1.0 / t
+                dir_path,
+                "model.layers." + str(i) + ".attention.qkv.scale_y_quant_orig.bin",
+                [1],
+                np.float32,
+            )
+            tensorrt_llm_qwen.layers[i].attention.kv_orig_quant_scale.value = 1.0 / t
             tensorrt_llm_qwen.layers[i].attention.kv_quant_orig_scale.value = t
 
     tok = time.time()
-    t = time.strftime('%H:%M:%S', time.gmtime(tok - tik))
-    tensorrt_llm.logger.info(f'Weights loaded. Total time: {t}')
+    t = time.strftime("%H:%M:%S", time.gmtime(tok - tik))
+    tensorrt_llm.logger.info(f"Weights loaded. Total time: {t}")
 
 
-def load_from_hf_qwen(tensorrt_llm_qwen: QWenForCausalLM,
-                       hf_qwen,
-                       mapping=Mapping(),
-                       #rank=0,
-                       #tensor_parallel=1,
-                       max_position_embeddings=8192,
-                       rotary_emb_base=10000,
-                       kv_channels=128,
-                       dtype="float32",
-                       multi_query_mode=False):
-    tensorrt_llm.logger.info('Loading weights from HF QWen...')
+def load_from_hf_qwen(
+    tensorrt_llm_qwen: QWenForCausalLM,
+    hf_qwen,
+    mapping=Mapping(),
+    # rank=0,
+    # tensor_parallel=1,
+    max_position_embeddings=8192,
+    rotary_emb_base=10000,
+    kv_channels=128,
+    dtype="float32",
+    multi_query_mode=False,
+):
+    tensorrt_llm.logger.info("Loading weights from HF QWen...")
     tik = time.time()
 
-    quant_mode = getattr(tensorrt_llm_qwen, 'quant_mode', QuantMode(0))
+    quant_mode = getattr(tensorrt_llm_qwen, "quant_mode", QuantMode(0))
     if quant_mode.is_int8_weight_only():
         plugin_weight_only_quant_type = torch.int8
     elif quant_mode.is_int4_weight_only():
@@ -482,22 +554,20 @@ def load_from_hf_qwen(tensorrt_llm_qwen: QWenForCausalLM,
     # tensorrt_llm_qwen.rope.position_embedding_cos.weight.value = torch_to_numpy(cos_weight)
     # tensorrt_llm_qwen.rope.position_embedding_sin.weight.value = torch_to_numpy(sin_weight)
     for k, v in tqdm(
-        model_params.items(),
-        total=len(model_params),
-        ncols=80,
-        desc="Converting..."
+        model_params.items(), total=len(model_params), ncols=80, desc="Converting..."
     ):
         if isinstance(v, list):
             v = [torch_to_numpy(vv.to(torch_dtype).detach().cpu()) for vv in v]
         else:
             v = torch_to_numpy(v.to(torch_dtype).detach().cpu())
-        if 'transformer.wte.weight' in k:
+        if "transformer.wte.weight" in k:
             tensorrt_llm_qwen.vocab_embedding.weight.value = v
-        elif 'transformer.ln_f.weight' in k:
+        elif "transformer.ln_f.weight" in k:
             tensorrt_llm_qwen.ln_f.weight.value = v
-        elif 'lm_head.weight' in k:
+        elif "lm_head.weight" in k:
             tensorrt_llm_qwen.lm_head.weight.value = np.ascontiguousarray(
-                split(v, mapping.tp_size, mapping.rank))
+                split(v, mapping.tp_size, mapping.rank)
+            )
         else:
             layer_idx = extract_layer_idx(k)
             if layer_idx is None:
@@ -505,11 +575,11 @@ def load_from_hf_qwen(tensorrt_llm_qwen: QWenForCausalLM,
             idx = int(layer_idx)
             if idx >= tensorrt_llm_qwen.num_layers:
                 continue
-            if 'ln_1.weight' in k:
+            if "ln_1.weight" in k:
                 tensorrt_llm_qwen.layers[idx].ln_1.weight.value = v
-            elif 'ln_2.weight' in k:
+            elif "ln_2.weight" in k:
                 tensorrt_llm_qwen.layers[idx].ln_2.weight.value = v
-            elif 'attn.c_attn.weight' in k:
+            elif "attn.c_attn.weight" in k:
                 dst = tensorrt_llm_qwen.layers[idx].attention.qkv.weight
                 if multi_query_mode:
                     assert isinstance(v, list) and len(v) == 3
@@ -522,21 +592,26 @@ def load_from_hf_qwen(tensorrt_llm_qwen: QWenForCausalLM,
                     model_emb = v.shape[1]
                     v = v.reshape(3, q_emb, model_emb)
                     split_v = split(v, mapping.tp_size, mapping.rank, dim=1)
-                    split_v = split_v.reshape(3 * (q_emb // mapping.tp_size),
-                                              model_emb)
+                    split_v = split_v.reshape(3 * (q_emb // mapping.tp_size), model_emb)
                 if use_weight_only:
                     v = np.ascontiguousarray(split_v.transpose())
-                    processed_torch_weights, torch_weight_scales = torch.ops.fastertransformer.symmetric_quantize_last_axis_of_batched_matrix(
-                        torch.tensor(v), plugin_weight_only_quant_type)
+                    (
+                        processed_torch_weights,
+                        torch_weight_scales,
+                    ) = torch.ops.fastertransformer.symmetric_quantize_last_axis_of_batched_matrix(
+                        torch.tensor(v), plugin_weight_only_quant_type
+                    )
                     # workaround for trt not supporting int8 inputs in plugins currently
                     dst.value = processed_torch_weights.view(
-                        dtype=torch.float32).numpy()
+                        dtype=torch.float32
+                    ).numpy()
                     scales = tensorrt_llm_qwen.layers[
-                        idx].attention.qkv.per_channel_scale
+                        idx
+                    ].attention.qkv.per_channel_scale
                     scales.value = torch_weight_scales.numpy()
                 else:
                     dst.value = np.ascontiguousarray(split_v)
-            elif 'attn.c_attn.bias' in k:
+            elif "attn.c_attn.bias" in k:
                 dst = tensorrt_llm_qwen.layers[idx].attention.qkv.bias
                 if multi_query_mode:
                     assert isinstance(v, list) and len(v) == 3
@@ -550,63 +625,81 @@ def load_from_hf_qwen(tensorrt_llm_qwen: QWenForCausalLM,
                     split_v = split(v, mapping.tp_size, mapping.rank, dim=1)
                     split_v = split_v.reshape(3 * (q_emb // mapping.tp_size))
                 dst.value = np.ascontiguousarray(split_v)
-            elif 'attn.c_proj.weight' in k:
+            elif "attn.c_proj.weight" in k:
                 dst = tensorrt_llm_qwen.layers[idx].attention.dense.weight
                 split_v = split(v, mapping.tp_size, mapping.rank, dim=1)
                 if use_weight_only:
                     v = np.ascontiguousarray(split_v.transpose())
-                    processed_torch_weights, torch_weight_scales = torch.ops.fastertransformer.symmetric_quantize_last_axis_of_batched_matrix(
-                        torch.tensor(v), plugin_weight_only_quant_type)
+                    (
+                        processed_torch_weights,
+                        torch_weight_scales,
+                    ) = torch.ops.fastertransformer.symmetric_quantize_last_axis_of_batched_matrix(
+                        torch.tensor(v), plugin_weight_only_quant_type
+                    )
                     # workaround for trt not supporting int8 inputs in plugins currently
                     dst.value = processed_torch_weights.view(
-                        dtype=torch.float32).numpy()
+                        dtype=torch.float32
+                    ).numpy()
                     scales = tensorrt_llm_qwen.layers[
-                        idx].attention.dense.per_channel_scale
+                        idx
+                    ].attention.dense.per_channel_scale
                     scales.value = torch_weight_scales.numpy()
                 else:
                     dst.value = np.ascontiguousarray(split_v)
-            elif 'mlp.w1.weight' in k:
+            elif "mlp.w1.weight" in k:
                 dst = tensorrt_llm_qwen.layers[idx].mlp.w1.weight
                 split_v = split(v, mapping.tp_size, mapping.rank, dim=0)
                 if use_weight_only:
                     v = np.ascontiguousarray(split_v.transpose())
-                    processed_torch_weights, torch_weight_scales = torch.ops.fastertransformer.symmetric_quantize_last_axis_of_batched_matrix(
-                        torch.tensor(v), plugin_weight_only_quant_type)
+                    (
+                        processed_torch_weights,
+                        torch_weight_scales,
+                    ) = torch.ops.fastertransformer.symmetric_quantize_last_axis_of_batched_matrix(
+                        torch.tensor(v), plugin_weight_only_quant_type
+                    )
                     # workaround for trt not supporting int8 inputs in plugins currently
                     dst.value = processed_torch_weights.view(
-                        dtype=torch.float32).numpy()
-                    scales = tensorrt_llm_qwen.layers[
-                        idx].mlp.w1.per_channel_scale
+                        dtype=torch.float32
+                    ).numpy()
+                    scales = tensorrt_llm_qwen.layers[idx].mlp.w1.per_channel_scale
                     scales.value = torch_weight_scales.numpy()
                 else:
                     dst.value = np.ascontiguousarray(split_v)
-            elif 'mlp.w2.weight' in k:
+            elif "mlp.w2.weight" in k:
                 dst = tensorrt_llm_qwen.layers[idx].mlp.w2.weight
                 split_v = split(v, mapping.tp_size, mapping.rank, dim=0)
                 if use_weight_only:
                     v = np.ascontiguousarray(split_v.transpose())
-                    processed_torch_weights, torch_weight_scales = torch.ops.fastertransformer.symmetric_quantize_last_axis_of_batched_matrix(
-                        torch.tensor(v), plugin_weight_only_quant_type)
+                    (
+                        processed_torch_weights,
+                        torch_weight_scales,
+                    ) = torch.ops.fastertransformer.symmetric_quantize_last_axis_of_batched_matrix(
+                        torch.tensor(v), plugin_weight_only_quant_type
+                    )
                     # workaround for trt not supporting int8 inputs in plugins currently
                     dst.value = processed_torch_weights.view(
-                        dtype=torch.float32).numpy()
-                    scales = tensorrt_llm_qwen.layers[
-                        idx].mlp.w2.per_channel_scale
+                        dtype=torch.float32
+                    ).numpy()
+                    scales = tensorrt_llm_qwen.layers[idx].mlp.w2.per_channel_scale
                     scales.value = torch_weight_scales.numpy()
                 else:
                     dst.value = np.ascontiguousarray(split_v)
-            elif 'mlp.c_proj.weight' in k:
+            elif "mlp.c_proj.weight" in k:
                 dst = tensorrt_llm_qwen.layers[idx].mlp.c_proj.weight
                 split_v = split(v, mapping.tp_size, mapping.rank, dim=1)
                 if use_weight_only:
                     v = np.ascontiguousarray(split_v.transpose())
-                    processed_torch_weights, torch_weight_scales = torch.ops.fastertransformer.symmetric_quantize_last_axis_of_batched_matrix(
-                        torch.tensor(v), plugin_weight_only_quant_type)
+                    (
+                        processed_torch_weights,
+                        torch_weight_scales,
+                    ) = torch.ops.fastertransformer.symmetric_quantize_last_axis_of_batched_matrix(
+                        torch.tensor(v), plugin_weight_only_quant_type
+                    )
                     # workaround for trt not supporting int8 inputs in plugins currently
                     dst.value = processed_torch_weights.view(
-                        dtype=torch.float32).numpy()
-                    scales = tensorrt_llm_qwen.layers[
-                        idx].mlp.c_proj.per_channel_scale
+                        dtype=torch.float32
+                    ).numpy()
+                    scales = tensorrt_llm_qwen.layers[idx].mlp.c_proj.per_channel_scale
                     scales.value = torch_weight_scales.numpy()
                 else:
                     dst.value = np.ascontiguousarray(split_v)
@@ -614,6 +707,6 @@ def load_from_hf_qwen(tensorrt_llm_qwen: QWenForCausalLM,
                 print("unknow key: ", k)
 
     tok = time.time()
-    t = time.strftime('%H:%M:%S', time.gmtime(tok - tik))
-    tensorrt_llm.logger.info(f'Weights loaded. Total time: {t}')
+    t = time.strftime("%H:%M:%S", time.gmtime(tok - tik))
+    tensorrt_llm.logger.info(f"Weights loaded. Total time: {t}")
     return

--- a/qwen/weight.py
+++ b/qwen/weight.py
@@ -2,6 +2,8 @@ import time
 import configparser
 from pathlib import Path
 import os
+
+from safetensors import safe_open
 from tqdm import trange
 import numpy as np
 import torch
@@ -710,3 +712,227 @@ def load_from_hf_qwen(
     t = time.strftime("%H:%M:%S", time.gmtime(tok - tik))
     tensorrt_llm.logger.info(f"Weights loaded. Total time: {t}")
     return
+
+
+def load_from_gptq_qwen(
+    tensorrt_llm_qwen: QWenForCausalLM,
+    quant_ckpt_path,
+    mapping=Mapping(),
+    dtype="float16",
+):
+    tensorrt_llm.logger.info("loading weights from groupwise gptq qwen safetensors...")
+    tik = time.time()
+
+    if quant_ckpt_path.endswith(".safetensors"):
+        groupwise_qweight_safetensors = safe_open(
+            quant_ckpt_path, framework="pt", device=0
+        )
+        model_params = {
+            key: groupwise_qweight_safetensors.get_tensor(key)
+            for key in groupwise_qweight_safetensors.keys()
+        }
+    elif quant_ckpt_path.endswith(".pt"):
+        model_params = torch.load(quant_ckpt_path, map_location=torch.device("cpu"))
+    else:
+        raise ValueError("quantized checkpoint format not supported!")
+
+    def unpack_int32_into_int8(w_packed):
+        # unpack inputs packed in int32/float32 into uint4 and store them in int8 format
+        w_packed_int4x2 = w_packed.contiguous().view(torch.uint8)
+        w_unpacked = torch.zeros(
+            w_packed_int4x2.shape[0], w_packed_int4x2.shape[1] * 2, dtype=torch.int8
+        )
+        w_unpacked[:, ::2] = w_packed_int4x2 % 16
+        w_unpacked[:, 1::2] = w_packed_int4x2 // 16
+        return w_unpacked.contiguous()
+
+    def preprocess_groupwise_weight_params(
+        weight_name,
+        qweight_int32=None,
+        qzeros_int32=None,
+        scales_fp16=None,
+    ):
+        if weight_name is not None:
+            qweight_int32 = model_params[weight_name].cpu()
+            qzeros_int32 = model_params[weight_name[:-7] + "qzeros"].cpu()
+            scales_fp16 = model_params[weight_name[:-7] + "scales"].cpu()
+
+        UINT4_TO_INT4_FLAG = 1
+        GPTQ_FLAG = 1
+        packer = torch.ops.fastertransformer.pack_int8_tensor_to_packed_int4
+        preprocessor = torch.ops.fastertransformer.preprocess_weights_for_mixed_gemm
+
+        qweight_unpacked_int8 = (
+            unpack_int32_into_int8(qweight_int32.T).T.contiguous() - 8
+        )
+        qweight_interleaved = preprocessor(
+            packer(qweight_unpacked_int8), torch.quint4x2
+        ).view(torch.float32)
+        # zeros = zeros * scales
+        qzeros_unpacked_int32 = unpack_int32_into_int8(qzeros_int32)
+
+        zeros_x_scales_fp16 = (
+            -qzeros_unpacked_int32 + 8 * UINT4_TO_INT4_FLAG - GPTQ_FLAG
+        ) * scales_fp16
+        zeros_x_scales_fp16 = zeros_x_scales_fp16.half()
+
+        # return processed interleaved weight, original scales and zeros * scales
+        return (
+            qweight_interleaved.contiguous(),
+            scales_fp16.contiguous(),
+            zeros_x_scales_fp16.contiguous(),
+        )
+
+    layer_ids = [extract_layer_idx(key) for key in groupwise_qweight_safetensors.keys()]
+    layer_ids = [int(layer_idx) for layer_idx in layer_ids if layer_idx is not None]
+    num_hidden_layers = max(layer_ids) + 1
+    num_kv_heads = tensorrt_llm_qwen.num_kv_heads
+    mha_mode = num_kv_heads == tensorrt_llm_qwen.num_heads
+    suffixs = ["qweight", "qzeros", "scales"]
+
+    layers_per_pipeline_stage = num_hidden_layers // mapping.pp_size
+    layers_range = list(
+        range(
+            mapping.pp_rank * layers_per_pipeline_stage,
+            (mapping.pp_rank + 1) * layers_per_pipeline_stage,
+            1,
+        )
+    )
+
+    for l in layers_range:
+        prefix = f"transformer.h.{l}.attn."
+        split_qkv_suf = []
+
+        for suf in suffixs:
+            qkv_part = model_params[prefix + "c_attn." + suf].cpu()  #
+            q_part, k_part, v_part = qkv_part.split(qkv_part.shape[1] // 3, dim=1)
+            qkv_part = torch.cat([q_part, k_part, v_part], dim=0)
+            dim = qkv_part.shape
+            qkv_part = qkv_part.reshape(3, dim[0] // 3, dim[1])
+            split_qkv = qkv_part.split(dim[1] // mapping.tp_size, dim=2)[
+                mapping.tp_rank
+            ]
+            split_qkv = torch.cat(
+                [
+                    split_qkv[0, :, :].squeeze(0),
+                    split_qkv[1, :, :].squeeze(0),
+                    split_qkv[2, :, :].squeeze(0),
+                ],
+                dim=1,
+            )
+            split_qkv_suf.append(split_qkv)
+
+        th_bias = model_params[prefix + "c_attn.bias"].cpu().contiguous()
+        th_qweight, th_zero, th_scale = preprocess_groupwise_weight_params(
+            None,
+            split_qkv_suf[0],
+            split_qkv_suf[1],
+            split_qkv_suf[2],
+        )
+
+        idx = l - mapping.pp_rank * layers_per_pipeline_stage
+        tensorrt_llm_qwen.layers[idx].attention.qkv.qweight.value = th_qweight.numpy()
+        tensorrt_llm_qwen.layers[idx].attention.qkv.bias.value = th_bias.numpy()
+        tensorrt_llm_qwen.layers[idx].attention.qkv.scale.value = th_zero.numpy()
+        tensorrt_llm_qwen.layers[idx].attention.qkv.zero.value = th_scale.numpy()
+
+    torch_dtype = str_dtype_to_torch(dtype)
+
+    for k, v in model_params.items():
+        if isinstance(v, list):
+            v = [torch_to_numpy(vv.to(torch_dtype).detach().cpu()) for vv in v]
+        else:
+            v = torch_to_numpy(v.to(torch_dtype).detach().cpu())
+
+        if "transformer.wte.weight" in k:
+            if mapping.is_first_pp_rank():
+                tensorrt_llm.logger.info(f"converting: {k}")
+                tensorrt_llm_qwen.vocab_embedding.weight.value = v
+        elif "transformer.ln_f.weight" in k:
+            if mapping.is_last_pp_rank():
+                tensorrt_llm_qwen.ln_f.weight.value = v
+        elif "lm_head.weight" in k:
+            tensorrt_llm_qwen.lm_head.weight.value = np.ascontiguousarray(
+                split(v, mapping.tp_size, mapping.rank)
+            )
+        else:
+            layer_idx = extract_layer_idx(k)
+            if layer_idx is None:
+                continue
+            idx = int(layer_idx)
+            if idx not in layers_range:
+                continue
+            idx = idx - mapping.pp_rank * layers_per_pipeline_stage
+
+            if "ln_1.weight" in k:
+                tensorrt_llm_qwen.layers[idx].ln_1.weight.value = v
+            elif "ln_2.weight" in k:
+                tensorrt_llm_qwen.layers[idx].ln_2.weight.value = v
+            elif "attn.c_proj.qweight" in k:
+                split_v_suf = []
+                for suf in suffixs:
+                    v = model_params[k[:-7] + suf].cpu()
+                    split_v = v.split(v.shape[0] // mapping.tp_size, dim=0)[
+                        mapping.tp_rank
+                    ]
+                    split_v_suf.append(split_v)
+                th_qweight, th_zero, th_scale = preprocess_groupwise_weight_params(
+                    None, split_v_suf[0], split_v_suf[1], split_v_suf[2]
+                )
+                tensorrt_llm_qwen.layers[
+                    idx
+                ].attention.dense.qweight.value = th_qweight.numpy()
+                tensorrt_llm_qwen.layers[
+                    idx
+                ].attention.dense.scale.value = th_zero.numpy()
+                tensorrt_llm_qwen.layers[
+                    idx
+                ].attention.dense.zero.value = th_scale.numpy()
+            elif "mlp.w1.qweight" in k:
+                split_v_suf = []
+                for suf in suffixs:
+                    v = model_params[k[:-7] + suf].cpu()
+                    split_v = v.split(v.shape[1] // mapping.tp_size, dim=1)[
+                        mapping.tp_rank
+                    ]
+                    split_v_suf.append(split_v)
+                th_qweight, th_zero, th_scale = preprocess_groupwise_weight_params(
+                    None, split_v_suf[0], split_v_suf[1], split_v_suf[2]
+                )
+                tensorrt_llm_qwen.layers[idx].mlp.w1.qweight.value = th_qweight.numpy()
+                tensorrt_llm_qwen.layers[idx].mlp.w1.scale.value = th_zero.numpy()
+                tensorrt_llm_qwen.layers[idx].mlp.w1.zero.value = th_scale.numpy()
+            elif "mlp.c_proj.qweight" in k:
+                split_v_suf = []
+                for suf in suffixs:
+                    v = model_params[k[:-7] + suf].cpu()
+                    split_v = v.split(v.shape[0] // mapping.tp_size, dim=0)[
+                        mapping.tp_rank
+                    ]
+                    split_v_suf.append(split_v)
+                th_qweight, th_zero, th_scale = preprocess_groupwise_weight_params(
+                    None, split_v_suf[0], split_v_suf[1], split_v_suf[2]
+                )
+                tensorrt_llm_qwen.layers[
+                    idx
+                ].mlp.c_proj.qweight.value = th_qweight.numpy()
+                tensorrt_llm_qwen.layers[idx].mlp.c_proj.scale.value = th_zero.numpy()
+                tensorrt_llm_qwen.layers[idx].mlp.c_proj.zero.value = th_scale.numpy()
+            elif "mlp.w2.qweight" in k:
+                split_v_suf = []
+                for suf in suffixs:
+                    v = model_params[k[:-7] + suf].cpu()
+                    split_v = v.split(v.shape[1] // mapping.tp_size, dim=1)[
+                        mapping.tp_rank
+                    ]
+                    split_v_suf.append(split_v)
+                th_qweight, th_zero, th_scale = preprocess_groupwise_weight_params(
+                    None, split_v_suf[0], split_v_suf[1], split_v_suf[2]
+                )
+                tensorrt_llm_qwen.layers[idx].mlp.w2.qweight.value = th_qweight.numpy()
+                tensorrt_llm_qwen.layers[idx].mlp.w2.scale.value = th_zero.numpy()
+                tensorrt_llm_qwen.layers[idx].mlp.w2.zero.value = th_scale.numpy()
+
+    tok = time.time()
+    t = time.strftime("%h:%m:%s", time.gmtime(tok - tik))
+    tensorrt_llm.logger.info(f"weights loaded. total time: {t}")


### PR DESCRIPTION
主要修改在 7ae309aec745268d964ed69cc58234193dd9854f，参考 llama 的 [load_from_gptq_llama](https://github.com/NVIDIA/TensorRT-LLM/blob/71a5b97b9c588bd2b9688facd5e82307cad98026/examples/llama/weight.py#L839) 实现了 `load_from_gptq_qwen`

1. 使用 [autogptq](https://github.com/PanQiWei/AutoGPTQ) 量化模型，具体的操作可以看 autogptq 的文档
2. 执行 `build.py` 脚本 build trtllm-engine：
```bash
python build.py --hf_model_dir /path/to/hf-model \
                --quant_ckpt_path /path/to/gptq_model-4bit-128g.safetensors \
                --dtype float16 \
                --remove_input_padding \
                --use_gpt_attention_plugin float16 \
                --enable_context_fmha \
                --use_gemm_plugin float16 \
                --use_weight_only \
                --weight_only_precision int4_gptq \
                --per_group \
                --world_size 1 \
                --tp_size 1 \
                --output_dir /path/to/save_model_dir/1-gpu/trtllm-int4-gptq
```

TODO: 目前 build.py 脚本只测试了 world_size/tp_size = 1